### PR TITLE
podspec did not include sub-directories

### DIFF
--- a/SpeedLog.podspec
+++ b/SpeedLog.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.source_files = 'Source/*.swift'
+  s.source_files = 'Source/**/*.swift'
   s.watchos.exclude_files = "Source/UIKit"
 
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-D ENABLE_LOG' }


### PR DESCRIPTION
file glob in podspec so sub-directories are included when we pod install SpeedLog
